### PR TITLE
[chore]pusher JS actionのnode update

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ inputs:
   body:
     description: "web-socket body"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Background / Why (背景と理由)

[EC-1080: \[chore\]pusher JS actionのnode update](https://linear.app/diggle/issue/EC-1080/chorepusher-js-actionのnode-update)

nodeバージョンを24へアップデートする。

## What (やったこと)

- nodeバージョンを24へアップデートした
- update後に`npm ci && npm run package && npm test`を実施し、testが通ること、ビルド結果に差分がないことを確認した

### Unscoped (まだやってないこと)[任意]

このpublish(2.0.0)して、cabernet側にて参照を変えます

## 主にレビューしていただきたい点

- [ ] サクッと〜

