### PR TITLE
Takumi Guard の適用

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          TAKUMI_GUARD_TOKEN: ${{ secrets.TAKUMI_GUARD_TOKEN }}
 
       - name: Run tests
         run: npm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# https://github.com/dependabot/dependabot-core/issues/8242#issuecomment-1799149003
+registry=https://npm.flatt.tech/
+//npm.flatt.tech/:_authToken=${TAKUMI_GUARD_TOKEN}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ https://pusher.com/
 # License
 
 This code is free to use under the terms of the MIT license.
+
+# Takumi Guard について
+
+Flatt Security が提供する npm レジストリプロキシ [Takumi Guard](https://flatt.tech/products/takumi-guard) を導入しています。  
+
+[Takumi Guard について](https://github.com/diggle-jp/cabernet/wiki/Takumi-Guard-%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "npmrc": "registry=https://npm.flatt.tech/",
   "schedule": [
     "before 9am on the first day of the month"
   ]


### PR DESCRIPTION
<!-- Instructions for GitHub Copilot code review: Please review this pull request and comment in Japanese. -->
<!-- I want to review in Japanese. -->
## 関連URL
Takumi Guardドキュメント：https://shisho.dev/docs/ja/t/guard/
Linear：https://linear.app/diggle/issue/EC-1070/takumi-gurd%E9%81%93%E5%85%A5pusher-trigger

## Background / Why (背景と理由)
cabernetと同様にTakumi Guardを導入します。

パッケージインストール時のセキュリティ強化のためTakumi Guardを導入する。
・Takumi Guard は npm（レジストリ）との間に位置するセキュリティプロキシで、悪意あるパッケージがブロックされる
・ Flatt Security社で全ての新規パッケージを検査し、ブロックリストを構築している


## What (やったこと)

### CI への Takumi Guard 適用

- `.github/workflows/test.yaml `の変更
    - npm ci 実行時に `TAKUMI_GUARD_TOKEN: ${{ secrets.TAKUMI_GUARD_TOKEN }} `を環境変数として渡すよう変更。CI 環境でも Takumi Guard 経由の認証インストールが有効になる。
- `.npmrc `の追加
    - デフォルトレジストリを `https://registry.npmjs.org/ `から Takumi Guard のプロキシ `https://npm.flatt.tech/ `に変更。`${TAKUMI_GUARD_TOKEN} `を auth token として設定し、npm がパッケージ取得時に Takumi Guard 経由で認証する構成に変更。
### Renovate への Takumi Guard 適用

- `renovate.json `の変更
    - npmrc フィールドにデフォルトレジストリとして` https://npm.flatt.tech/ `を追加。Renovate がアップデートチェックを行う際も Takumi Guard 経由になる。

## 主にレビューしていただきたい点
※必要に応じて適宜追加/削除/更新してください。  
- [ ] コードに問題がないか
- [ ] 違和感がないか

## スクリーンショット
 - 動作確認
     - 無効: `ERR_PNPM_FETCH_401 GET https://npm.flatt.tech/lodash: Unauthorized`
     → リクエストが Takumi Guard に到達しており、無効なトークンで認証が拒否されることを確認
     - 正しいトークン: pnpm add lodash が正常に完了
    → Takumi Guard の認証が通り、パッケージが正常にインストールされることを確認

  
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->
